### PR TITLE
Fix: TabType to Analytics and new CSV types added

### DIFF
--- a/src/components/CampaignAnalytics/CampaignAnalytics.tsx
+++ b/src/components/CampaignAnalytics/CampaignAnalytics.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, useMemo } from 'react'
 import { Container, Flex, Loader, Tabs } from '@mantine/core'
 import { useParams } from 'react-router-dom'
-import { AnalyticsType, TabType, BaseAnalyticsData, AnalyticsPeriod } from 'types'
+import { AnalyticsType, BaseAnalyticsData, AnalyticsPeriod } from 'types'
 import GoBack from 'components/common/GoBack/GoBack'
 import DownloadCSV from 'components/common/DownloadCSV'
 import useCampaignAnalytics from 'hooks/useCampaignAnalytics'
@@ -14,20 +14,6 @@ import Regions from './Regions'
 import { TimeFrame } from './TimeFrame'
 import { generateCVSData } from './CvsDownloadConfigurations'
 import SeeOnMapBtn from './SeeOnMapBtn'
-
-// TODO: temp - unify and use anal
-const analyticTypeToHeader = (aType: AnalyticsType): TabType => {
-  switch (aType) {
-    case 'country':
-      return 'regions'
-    case 'hostname':
-      return 'placements'
-    case 'adUnit':
-      return 'creatives'
-    default:
-      return 'timeframe'
-  }
-}
 
 const CampaignAnalytics = () => {
   const { id } = useParams()
@@ -112,7 +98,7 @@ const CampaignAnalytics = () => {
       setIsMapBtnShown(activeTab === 'country')
 
       // TODO: fix csf Data types an add the type to useState
-      setCsvData(generateCVSData(analyticTypeToHeader(activeTab), campaignMappedAnalytics))
+      setCsvData(generateCVSData(activeTab, campaignMappedAnalytics))
     }
   }, [activeTab, campaignMappedAnalytics])
 

--- a/src/components/CampaignAnalytics/CvsDownloadConfigurations.ts
+++ b/src/components/CampaignAnalytics/CvsDownloadConfigurations.ts
@@ -1,7 +1,7 @@
-import { IHeadersToDataProps, BaseAnalyticsData, TabType } from 'types'
+import { IHeadersToDataProps, BaseAnalyticsData, AnalyticsType } from 'types'
 
 const headersToDataProperties: IHeadersToDataProps = {
-  placements: {
+  hostname: {
     Website: 'segment',
     Impressions: 'impressions',
     Clicks: 'clicks',
@@ -9,7 +9,7 @@ const headersToDataProperties: IHeadersToDataProps = {
     Spent: 'paid',
     'Average CPM': 'avgCpm'
   },
-  regions: {
+  country: {
     Country: 'segment',
     Share: 'share',
     Impressions: 'impressions',
@@ -18,7 +18,7 @@ const headersToDataProperties: IHeadersToDataProps = {
     'Average CPM': 'avgCpm',
     Spent: 'paid'
   },
-  creatives: {
+  adUnit: {
     Impressions: 'impressions',
     Clicks: 'clicks',
     'CTR%': 'crt',
@@ -28,7 +28,7 @@ const headersToDataProperties: IHeadersToDataProps = {
 }
 
 // TODO: remove TabType use AnalyticsType
-const generateCVSData = (tabName: TabType, tabData: BaseAnalyticsData[] | undefined) => ({
+const generateCVSData = (tabName: AnalyticsType, tabData: BaseAnalyticsData[] | undefined) => ({
   mapHeadersToDataProperties: headersToDataProperties[tabName],
   tabData,
   filename: `${tabName}.csv`

--- a/src/types/campaignsData.ts
+++ b/src/types/campaignsData.ts
@@ -5,6 +5,7 @@ export type BaseData = {
   clicks: number
   // clicks / impressions * 100
   ctr?: number
+  share?: number
   // paid / impressions * 1000
   avgCpm?: number
   paid: number

--- a/src/types/cvsDownloadConfiguration.ts
+++ b/src/types/cvsDownloadConfiguration.ts
@@ -1,26 +1,32 @@
+export type Hostname = {
+  Website: string
+  Impressions: string
+  Clicks: string
+  'CRT%': string
+  Spent: string
+  'Average CPM': string
+}
+
+export type Country = {
+  Country: string
+  Share: string
+  Impressions: string
+  Clicks: string
+  'CTR%': string
+  'Average CPM': string
+  Spent: string
+}
+
+export type AdUnit = {
+  Impressions: string
+  Clicks: string
+  'CTR%': string
+  Spent: string
+}
+
 export interface IHeadersToDataProps {
-  placements: {
-    Website: string
-    Impressions: string
-    Clicks: string
-    'CRT%': string
-    Spent: string
-    'Average CPM': string
-  }
-  regions: {
-    Country: string
-    Share: string
-    Impressions: string
-    Clicks: string
-    'CTR%': string
-    'Average CPM': string
-    Spent: string
-  }
-  creatives: {
-    Impressions: string
-    Clicks: string
-    'CTR%': string
-    Spent: string
-  }
+  hostname: Hostname
+  country: Country
+  adUnit: AdUnit
   timeframe: object
 }


### PR DESCRIPTION
 - Removed analyticTypeToHeader function and implemented use of AnalyticsType instead of TabType
 - Changed src/components/CampaignAnalytics/CvsDownloadConfigurations.ts keys to be from AnalyticsType
 - Added types for src/components/common/DownloadCSV/DownloadCSV.tsx
 - Extracted and exported individual types of IHeadersToDataProps