### PR TITLE
Fix: fixed the listing of the banner sizes when the both devices were selected

### DIFF
--- a/src/components/CreateCampaign/StepOne/UploadedBanners.tsx
+++ b/src/components/CreateCampaign/StepOne/UploadedBanners.tsx
@@ -17,7 +17,7 @@ const UploadedBanners = ({
   } = useCreateCampaignContext()
 
   const allowedSizes = useMemo(
-    () => selectedBannerSizes.map((item) => item.value),
+    () => selectedBannerSizes.flat().map((item) => item.value),
     [selectedBannerSizes]
   )
 

--- a/src/helpers/createCampaignHelpers.ts
+++ b/src/helpers/createCampaignHelpers.ts
@@ -74,8 +74,7 @@ export const selectBannerSizes = (
 ): Record<string, SupplyStatsDetails[]> => ({
   app: supplyStats.appBannerFormats,
   mobile: supplyStats.siteBannerFormatsMobile,
-  desktop: supplyStats.siteBannerFormatsDesktop,
-  both: [...supplyStats.siteBannerFormatsMobile, ...supplyStats.siteBannerFormatsDesktop]
+  desktop: supplyStats.siteBannerFormatsDesktop
 })
 
 export const findDuplicates = (array: string[]) => {

--- a/src/types/createCampaignCommon.ts
+++ b/src/types/createCampaignCommon.ts
@@ -56,5 +56,5 @@ export type CreateCampaignType = {
   addAdUnit: (adUnitToAdd: AdUnit) => void
   removeAdUnit: (adUnitIdToRemove: string) => void
   addTargetURLToAdUnit: (inputText: string, adUnitId: string) => void
-  selectedBannerSizes: SupplyStatsDetails[]
+  selectedBannerSizes: SupplyStatsDetails[] | SupplyStatsDetails[][]
 }


### PR DESCRIPTION
Now it shows the 10 most popular banner sizes by device when mobile and desktop devices have been selected.