### PR TITLE
Add: Target input fields on step three

### DIFF
--- a/src/components/CreateCampaign/CampaignSummary.tsx
+++ b/src/components/CreateCampaign/CampaignSummary.tsx
@@ -49,7 +49,8 @@ const CampaignSummary = () => {
     formattedCats,
     formattedLocs,
     adFormats,
-    campaignBudgetFormatted
+    campaignBudgetFormatted,
+    advancedTargeInput
   } = useCreateCampaignData()
   const { showNotification } = useCustomNotifications()
 
@@ -167,12 +168,32 @@ const CampaignSummary = () => {
         />
         <CampaignDetailsRow lighterColor title="Ad Format" value={adFormats} textSize="sm" />
         <CampaignDetailsRow lighterColor title="Categories" value={formattedCats} textSize="sm" />
+        <CampaignDetailsRow lighterColor title="Countries" value={formattedLocs} textSize="sm" />
         <CampaignDetailsRow
+          mt="md"
           lighterColor
-          title="Countries"
-          value={formattedLocs}
+          lineHeight="xs"
+          title="Include incentivized traffic"
+          value={advancedTargeInput.includeIncentivized ? 'Yes' : 'No'}
           textSize="sm"
           noBorder
+        />
+        <CampaignDetailsRow
+          lighterColor
+          lineHeight="xs"
+          title="Disable frequency capping"
+          value={advancedTargeInput.disableFrequencyCapping ? 'Yes' : 'No'}
+          textSize="sm"
+          noBorder
+        />
+        <CampaignDetailsRow
+          lighterColor
+          lineHeight="xs"
+          title="Limit average daily spending"
+          value={advancedTargeInput.limitDailyAverageSpending ? 'Yes' : 'No'}
+          textSize="sm"
+          noBorder
+          mb="xs"
         />
       </Flex>
       {/* Temporary disabled */}

--- a/src/components/CreateCampaign/StepFour/StepFour.tsx
+++ b/src/components/CreateCampaign/StepFour/StepFour.tsx
@@ -21,6 +21,7 @@ const StepFour = () => {
     priceBoundsFormatted,
     formattedCats,
     formattedLocs,
+    advancedTargeInput,
     adFormats,
     campaignBudgetFormatted,
     campaignNameFormatted,
@@ -40,7 +41,22 @@ const StepFour = () => {
       { count: 7, title: 'Ad Format', value: adFormats },
       { count: 8, title: 'Creatives', value: adUnitsFormatted },
       { count: 9, title: 'Selected Categories', value: formattedCats },
-      { count: 10, title: 'Selected Countries', value: formattedLocs }
+      { count: 10, title: 'Selected Countries', value: formattedLocs },
+      {
+        count: 11,
+        title: 'Include incentivized traffic',
+        value: advancedTargeInput.includeIncentivized ? 'Yes' : 'No'
+      },
+      {
+        count: 12,
+        title: 'Disable frequency capping',
+        value: advancedTargeInput.disableFrequencyCapping ? 'Yes' : 'No'
+      },
+      {
+        count: 13,
+        title: 'Limit average daily spending',
+        value: advancedTargeInput.limitDailyAverageSpending ? 'Yes' : 'No'
+      }
     ],
     [
       formattedSelectedDevice,

--- a/src/components/CreateCampaign/StepThree/StepThree.tsx
+++ b/src/components/CreateCampaign/StepThree/StepThree.tsx
@@ -279,7 +279,7 @@ const StepThree = () => {
         </Grid.Col>
         <Grid.Col mb="md">
           <Text color="secondaryText" size="sm" weight="bold">
-            7. Additional options
+            7. Advanced options
           </Text>
           <Group my="sm">
             <Checkbox

--- a/src/components/CreateCampaign/StepThree/StepThree.tsx
+++ b/src/components/CreateCampaign/StepThree/StepThree.tsx
@@ -4,6 +4,11 @@ import InfoFilledIcon from 'resources/icons/InfoFilled'
 import useCreateCampaignContext from 'hooks/useCreateCampaignContext'
 import useAccount from 'hooks/useAccount'
 import {
+  CAMPAIGN_DISABLE_FREQUENCY_CAPPING_INPUT,
+  CAMPAIGN_INCLUDE_INCENTIVIZED_INPUT,
+  CAMPAIGN_LIMIT_DAILY_AVERAGE_SPENDING_INPUT
+} from 'constants/createCampaign'
+import {
   validateCPMMax,
   validateCPMMin,
   validateCampaignBudget,
@@ -48,13 +53,18 @@ const StepThree = () => {
       campaignBudget,
       cpmPricingBounds: { min, max },
       title,
-      asapStartingDate
+      asapStartingDate,
+      targetingInput: {
+        inputs: {
+          advanced: { disableFrequencyCapping, includeIncentivized, limitDailyAverageSpending }
+        }
+      }
     },
     updatePartOfCampaign,
     updateCampaign,
+    updateCampaignWithPrevStateNested,
     selectedBidFloors
   } = useCreateCampaignContext()
-
   const {
     adexAccount: { availableBalance, balanceToken },
     isAdmin
@@ -69,6 +79,13 @@ const StepThree = () => {
 
     return rangeUnparsed ? parseRange(rangeUnparsed) : { min: 'N/A', max: 'N/A' }
   }, [selectedBidFloors])
+
+  const handleTargetInputAdvanced = useCallback(
+    (key: string, value: boolean) => {
+      updateCampaignWithPrevStateNested(key, value)
+    },
+    [updateCampaignWithPrevStateNested]
+  )
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -260,13 +277,49 @@ const StepThree = () => {
             error={errors.title}
           />
         </Grid.Col>
+        <Grid.Col mb="md">
+          <Text color="secondaryText" size="sm" weight="bold">
+            7. Additional options
+          </Text>
+          <Group my="sm">
+            <Checkbox
+              checked={includeIncentivized}
+              label="Include incentivized traffic"
+              onChange={(event) =>
+                handleTargetInputAdvanced(
+                  CAMPAIGN_INCLUDE_INCENTIVIZED_INPUT,
+                  event.currentTarget.checked
+                )
+              }
+            />
+          </Group>
+          <Group my="sm">
+            <Checkbox
+              checked={disableFrequencyCapping}
+              label="Disable frequency capping"
+              onChange={(event) =>
+                handleTargetInputAdvanced(
+                  CAMPAIGN_DISABLE_FREQUENCY_CAPPING_INPUT,
+                  event.currentTarget.checked
+                )
+              }
+            />
+          </Group>
+          <Group my="sm">
+            <Checkbox
+              checked={limitDailyAverageSpending}
+              label="Limit average daily spending"
+              onChange={(event) =>
+                handleTargetInputAdvanced(
+                  CAMPAIGN_LIMIT_DAILY_AVERAGE_SPENDING_INPUT,
+                  event.currentTarget.checked
+                )
+              }
+            />
+          </Group>
+        </Grid.Col>
       </Grid>
-      <Button
-        type="button"
-        onClick={submitForm}
-        style={{ display: 'none' }}
-        id="createCampaignSubmitBtn1"
-      />
+      <Button type="button" onClick={submitForm} style={{ display: 'none' }} />
     </>
   )
 }

--- a/src/components/CreateCampaign/StepThree/StepThree.tsx
+++ b/src/components/CreateCampaign/StepThree/StepThree.tsx
@@ -319,7 +319,12 @@ const StepThree = () => {
           </Group>
         </Grid.Col>
       </Grid>
-      <Button type="button" onClick={submitForm} style={{ display: 'none' }} />
+      <Button
+        type="button"
+        onClick={submitForm}
+        style={{ display: 'none' }}
+        id="createCampaignSubmitBtn1"
+      />
     </>
   )
 }

--- a/src/components/common/CampainDetailsRow/CampaignDetailsRow.tsx
+++ b/src/components/common/CampainDetailsRow/CampaignDetailsRow.tsx
@@ -28,7 +28,8 @@ const CampaignDetailsRow = ({
   noBorder = false,
   column = false,
   lineHeight = 'lg',
-  nowrap = false
+  nowrap = false,
+  ...rest
 }: CampaignDetailsRowProps) => {
   const { classes, cx } = useStyles({ lighterColor: !!lighterColor })
   return (
@@ -40,6 +41,7 @@ const CampaignDetailsRow = ({
       pt={lineHeight}
       pb={lineHeight}
       gap="sm"
+      {...rest}
     >
       <Text
         className={cx(classes.textColor, {

--- a/src/constants/createCampaign.ts
+++ b/src/constants/createCampaign.ts
@@ -101,7 +101,7 @@ export const CREATE_CAMPAIGN_DEFAULT_VALUE: CampaignUI = {
       publishers: DEFAULT_CATS_LOCS_VALUE,
       placements: DEFAULT_PLACEMENTS_VALUE,
       advanced: {
-        includeIncentivized: true,
+        includeIncentivized: false,
         disableFrequencyCapping: false,
         limitDailyAverageSpending: false
       }

--- a/src/constants/createCampaign.ts
+++ b/src/constants/createCampaign.ts
@@ -10,6 +10,13 @@ export const CREATE_CAMPAIGN_STEPS = 4
 export const CAMPAIGN_CATEGORIES_INPUT = 'targetingInput.inputs.categories'
 export const CAMPAIGN_LOCATION_INPUT = 'targetingInput.inputs.location'
 export const CAMPAIGN_PLACEMENTS_INPUT = 'targetingInput.inputs.placements.in'
+export const CAMPAIGN_INCLUDE_INCENTIVIZED_INPUT =
+  'targetingInput.inputs.advanced.includeIncentivized'
+export const CAMPAIGN_DISABLE_FREQUENCY_CAPPING_INPUT =
+  'targetingInput.inputs.advanced.disableFrequencyCapping'
+export const CAMPAIGN_LIMIT_DAILY_AVERAGE_SPENDING_INPUT =
+  'targetingInput.inputs.advanced.limitDailyAverageSpending'
+
 const THIRTY_DAYS_IN_MILLISECONDS = 2592000000
 
 export const dateNowPlusThirtyDays = () => {

--- a/src/hooks/useCreateCampaignData/useCreateCampaignData.tsx
+++ b/src/hooks/useCreateCampaignData/useCreateCampaignData.tsx
@@ -21,6 +21,7 @@ const useCreateCampaignData = () => {
       devices,
       targetingInput: {
         inputs: {
+          advanced,
           location,
           categories,
           placements: {
@@ -160,6 +161,7 @@ const useCreateCampaignData = () => {
     formattedCats,
     formattedLocs,
     adFormats,
+    advancedTargeInput: advanced,
     campaignBudgetFormatted,
     campaignNameFormatted,
     adUnitsFormatted,


### PR DESCRIPTION
### **Changes in StepThree - Added checkboxes for:** 
- Include incentivized traffic
- Disable frequency capping
- Limit average daily spending
- Default value to all is false/No

**Changes in CreateCampaign:**
- Added constant holding the nesting keys of each value that the checkbox handles

![image](https://github.com/user-attachments/assets/df89de4f-6653-4f11-80e5-a195f4bc0864)

### **Changes in StepFour: Added the values from advanced to overview**

![image](https://github.com/user-attachments/assets/45f5b064-608d-40cc-b8ea-4d7fe04a8985)

### **Changes in CampaignSummary: Added the values from advanced to overview**

![image](https://github.com/user-attachments/assets/c4f7d048-1829-4959-b59c-8a7b711f5973)

