### PR TITLE
Bid for weak performing sources

### DIFF
--- a/src/components/CampaignDetails/CampaignDetails.tsx
+++ b/src/components/CampaignDetails/CampaignDetails.tsx
@@ -391,6 +391,11 @@ const CampaignDetails = ({ isAdminPanel }: { isAdminPanel?: boolean }) => {
                     />
                     <CampaignDetailsRow
                       textSize="sm"
+                      title="Loose source bidding"
+                      value={campaign.targetingInput.inputs.advanced.looseSourceCTR ? 'Yes' : 'No'}
+                    />
+                    <CampaignDetailsRow
+                      textSize="sm"
                       title="Last modified by"
                       noBorder
                       value={

--- a/src/components/CreateCampaign/CampaignSummary.tsx
+++ b/src/components/CreateCampaign/CampaignSummary.tsx
@@ -78,6 +78,13 @@ const CampaignSummary = ({ onLaunchClick }: { onLaunchClick: () => void }) => {
 
       <CampaignDetailsRow
         lighterColor
+        title="Loose source bidding"
+        value={advancedTargeInput.looseSourceCTR ? 'Yes' : 'No'}
+        textSize="sm"
+      />
+
+      <CampaignDetailsRow
+        lighterColor
         title="Auto UTM tracking"
         value={
           <Group gap="sm">

--- a/src/components/CreateCampaign/StepFour/StepFour.tsx
+++ b/src/components/CreateCampaign/StepFour/StepFour.tsx
@@ -32,6 +32,10 @@ const StepFour = () => {
         title: 'Aggressive bidding',
         value: advancedTargeInput.aggressiveBidding ? 'Yes' : 'No'
       },
+      {
+        title: 'Loose source bidding',
+        value: advancedTargeInput.looseSourceCTR ? 'Yes' : 'No'
+      },
       { title: 'Campaign Period', value: campaignPeriodFormatted },
       { title: 'Placements', value: formattedSelectedPlacement },
       { title: 'Device Type', value: formattedSelectedDevice },

--- a/src/components/CreateCampaign/StepFour/StepFour.tsx
+++ b/src/components/CreateCampaign/StepFour/StepFour.tsx
@@ -56,7 +56,8 @@ const StepFour = () => {
       formattedCats,
       formattedLocs,
       advancedTargeInput.limitDailyAverageSpending,
-      advancedTargeInput.aggressiveBidding
+      advancedTargeInput.aggressiveBidding,
+      advancedTargeInput.looseSourceCTR
     ]
   )
 

--- a/src/components/CreateCampaign/StepThree/StepThree.tsx
+++ b/src/components/CreateCampaign/StepThree/StepThree.tsx
@@ -180,6 +180,13 @@ const StepThree = () => {
               (learn more)
             </DefaultCustomAnchor>
           </Group>
+          <Checkbox
+            label="Bid on loose sources"
+            key={key('targetingInput.inputs.advanced.looseSourceCTR')}
+            {...getInputProps('targetingInput.inputs.advanced.looseSourceCTR', {
+              type: 'checkbox'
+            })}
+          />
         </Stack>
 
         <TextInput

--- a/src/components/EditCampaign/EditCampaign.tsx
+++ b/src/components/EditCampaign/EditCampaign.tsx
@@ -146,7 +146,8 @@ const EditCampaign = ({ campaign, isAdmin }: { campaign: Campaign; isAdmin?: boo
               typeof value !== 'boolean' ? 'Invalid value' : null,
             limitDailyAverageSpending: (value) =>
               typeof value !== 'boolean' ? 'Invalid value' : null,
-            aggressiveBidding: (value) => (typeof value !== 'boolean' ? 'Invalid value' : null)
+            aggressiveBidding: (value) => (typeof value !== 'boolean' ? 'Invalid value' : null),
+            looseSourceCTR: (value) => (typeof value !== 'boolean' ? 'Invalid value' : null)
           }
         }
       }
@@ -357,6 +358,12 @@ const EditCampaign = ({ campaign, isAdmin }: { campaign: Campaign; isAdmin?: boo
                       (learn more)
                     </DefaultCustomAnchor>
                   </Group>
+                  <Checkbox
+                    label="Bid on loose sources"
+                    {...form.getInputProps('targetingInput.inputs.advanced.looseSourceCTR', {
+                      type: 'checkbox'
+                    })}
+                  />
                 </Stack>
 
                 <Button disabled={!form.isDirty()} size="lg" type="submit" maw={200}>

--- a/src/constants/createCampaign.ts
+++ b/src/constants/createCampaign.ts
@@ -86,7 +86,8 @@ export const CREATE_CAMPAIGN_DEFAULT_VALUE: CampaignUI = {
         includeIncentivized: false,
         disableFrequencyCapping: false,
         limitDailyAverageSpending: false,
-        aggressiveBidding: false
+        aggressiveBidding: false,
+        looseSourceCTR: false
       }
     }
   },


### PR DESCRIPTION
#314

Added option for bidding on weak performing sources on campaign create step 3 and campaign edit. (looseSourceCTR):
On create campaign:
![image](https://github.com/user-attachments/assets/57eff04b-d401-4ce5-9dc6-5a559bd2a72c)
On edit campaign:
![image](https://github.com/user-attachments/assets/723281cc-99ea-4114-b9f4-713773830173)

Added row for displaying looseSourceCTR:
On create campaign:
![image](https://github.com/user-attachments/assets/4fe3ef37-dabf-4f9e-8687-69362eafe072)
On campaign details:
![image](https://github.com/user-attachments/assets/48a2f6d4-3bf0-43c9-a1bf-262c59c77e42)


