### PR TITLE
fix: superseded defaultProperty on icons

### DIFF
--- a/src/resources/icons/Active.tsx
+++ b/src/resources/icons/Active.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const ActiveIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const ActiveIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 8.494 9.03"
@@ -20,7 +24,5 @@ const ActiveIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest 
     </svg>
   )
 }
-
-ActiveIcon.defaultProps = defaultProps
 
 export default ActiveIcon

--- a/src/resources/icons/AddCart.tsx
+++ b/src/resources/icons/AddCart.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const AddCartIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const AddCartIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 24 24"
@@ -43,7 +48,5 @@ const AddCartIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-AddCartIcon.defaultProps = defaultProps
 
 export default AddCartIcon

--- a/src/resources/icons/AddSigner.tsx
+++ b/src/resources/icons/AddSigner.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const AddSignerIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const AddSignerIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -32,7 +37,5 @@ const AddSignerIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-AddSignerIcon.defaultProps = defaultProps
 
 export default AddSignerIcon

--- a/src/resources/icons/Analytics.tsx
+++ b/src/resources/icons/Analytics.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const AnalyticsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const AnalyticsIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -30,7 +35,5 @@ const AnalyticsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-AnalyticsIcon.defaultProps = defaultProps
 
 export default AnalyticsIcon

--- a/src/resources/icons/Archived.tsx
+++ b/src/resources/icons/Archived.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const ArchivedIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const ArchivedIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg viewBox="0 0 9 9" xmlns="http://www.w3.org/2000/svg" width={size} height={size} {...rest}>
       <g fill="none" stroke={color} strokeLinecap="round" data-name="archived icon">
@@ -18,7 +22,5 @@ const ArchivedIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...res
     </svg>
   )
 }
-
-ArchivedIcon.defaultProps = defaultProps
 
 export default ArchivedIcon

--- a/src/resources/icons/Attention.tsx
+++ b/src/resources/icons/Attention.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const AttentionIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const AttentionIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 27.051 25.5"
@@ -22,7 +27,5 @@ const AttentionIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-AttentionIcon.defaultProps = defaultProps
 
 export default AttentionIcon

--- a/src/resources/icons/Bell.tsx
+++ b/src/resources/icons/Bell.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const BellIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const BellIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 17.565 21.62"
@@ -26,7 +31,5 @@ const BellIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-BellIcon.defaultProps = defaultProps
 
 export default BellIcon

--- a/src/resources/icons/Billing.tsx
+++ b/src/resources/icons/Billing.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const BillingIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const BillingIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 26 26"
@@ -32,7 +37,5 @@ const BillingIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-BillingIcon.defaultProps = defaultProps
 
 export default BillingIcon

--- a/src/resources/icons/BillingDetails.tsx
+++ b/src/resources/icons/BillingDetails.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const BillingDetailsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const BillingDetailsIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 23.459 25.85"
@@ -32,7 +37,5 @@ const BillingDetailsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, 
     </svg>
   )
 }
-
-BillingDetailsIcon.defaultProps = defaultProps
 
 export default BillingDetailsIcon

--- a/src/resources/icons/Block.tsx
+++ b/src/resources/icons/Block.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const ActiveIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const ActiveIcon: React.FC<AppIconProps> = ({ size = defaultProps.size, ...rest }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -35,7 +35,5 @@ const ActiveIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest 
     </svg>
   )
 }
-
-ActiveIcon.defaultProps = defaultProps
 
 export default ActiveIcon

--- a/src/resources/icons/Calendar.tsx
+++ b/src/resources/icons/Calendar.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CalendarIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const CalendarIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.767 24"
@@ -49,7 +53,5 @@ const CalendarIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-CalendarIcon.defaultProps = defaultProps
 
 export default CalendarIcon

--- a/src/resources/icons/Campaign.tsx
+++ b/src/resources/icons/Campaign.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CampaignIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const CampaignIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 36 36"
@@ -23,7 +28,5 @@ const CampaignIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...res
     </svg>
   )
 }
-
-CampaignIcon.defaultProps = defaultProps
 
 export default CampaignIcon

--- a/src/resources/icons/CheckMark.tsx
+++ b/src/resources/icons/CheckMark.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CheckMarkIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const CheckMarkIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -21,7 +26,5 @@ const CheckMarkIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-CheckMarkIcon.defaultProps = defaultProps
 
 export default CheckMarkIcon

--- a/src/resources/icons/CheckMarkFilled.tsx
+++ b/src/resources/icons/CheckMarkFilled.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CheckMarkFilledIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const CheckMarkFilledIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 20 20"
@@ -28,7 +33,5 @@ const CheckMarkFilledIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth,
     </svg>
   )
 }
-
-CheckMarkFilledIcon.defaultProps = defaultProps
 
 export default CheckMarkFilledIcon

--- a/src/resources/icons/Close.tsx
+++ b/src/resources/icons/Close.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CloseIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const CloseIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 32 32"
@@ -36,7 +41,5 @@ const CloseIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }
     </svg>
   )
 }
-
-CloseIcon.defaultProps = defaultProps
 
 export default CloseIcon

--- a/src/resources/icons/CompletedIcon.tsx
+++ b/src/resources/icons/CompletedIcon.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CompletedIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const CompletedIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 14 14"
@@ -26,7 +30,5 @@ const CompletedIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-CompletedIcon.defaultProps = defaultProps
 
 export default CompletedIcon

--- a/src/resources/icons/Copy.tsx
+++ b/src/resources/icons/Copy.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const CopyIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const CopyIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 25.5 25.5"
@@ -29,7 +34,5 @@ const CopyIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-CopyIcon.defaultProps = defaultProps
 
 export default CopyIcon

--- a/src/resources/icons/Dashboard.tsx
+++ b/src/resources/icons/Dashboard.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DashboardIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DashboardIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 26 26"
@@ -27,7 +32,5 @@ const DashboardIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-DashboardIcon.defaultProps = defaultProps
 
 export default DashboardIcon

--- a/src/resources/icons/Delete.tsx
+++ b/src/resources/icons/Delete.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DeleteIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DeleteIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 19.64 21.5"
@@ -35,7 +40,5 @@ const DeleteIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest 
     </svg>
   )
 }
-
-DeleteIcon.defaultProps = defaultProps
 
 export default DeleteIcon

--- a/src/resources/icons/Deposit.tsx
+++ b/src/resources/icons/Deposit.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DepositIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DepositIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 38.757 36"
@@ -43,7 +48,5 @@ const DepositIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-DepositIcon.defaultProps = defaultProps
 
 export default DepositIcon

--- a/src/resources/icons/Desktop.tsx
+++ b/src/resources/icons/Desktop.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DesktopIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DesktopIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 36.8 36.783"
@@ -24,7 +29,5 @@ const DesktopIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-DesktopIcon.defaultProps = defaultProps
 
 export default DesktopIcon

--- a/src/resources/icons/DownArrow.tsx
+++ b/src/resources/icons/DownArrow.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DownArrowIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DownArrowIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 10.519 6.01"
@@ -23,7 +28,5 @@ const DownArrowIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-DownArrowIcon.defaultProps = defaultProps
 
 export default DownArrowIcon

--- a/src/resources/icons/DownChevron.tsx
+++ b/src/resources/icons/DownChevron.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DownChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DownChevronIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -26,7 +31,5 @@ const DownChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...
     </svg>
   )
 }
-
-DownChevronIcon.defaultProps = defaultProps
 
 export default DownChevronIcon

--- a/src/resources/icons/Download.tsx
+++ b/src/resources/icons/Download.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DownloadIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DownloadIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -28,7 +33,5 @@ const DownloadIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...res
     </svg>
   )
 }
-
-DownloadIcon.defaultProps = defaultProps
 
 export default DownloadIcon

--- a/src/resources/icons/Draft.tsx
+++ b/src/resources/icons/Draft.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DraftIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const DraftIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 14 14"
@@ -33,7 +37,5 @@ const DraftIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-DraftIcon.defaultProps = defaultProps
 
 export default DraftIcon

--- a/src/resources/icons/Duplicate.tsx
+++ b/src/resources/icons/Duplicate.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const DuplicateIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const DuplicateIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -30,7 +35,5 @@ const DuplicateIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-DuplicateIcon.defaultProps = defaultProps
 
 export default DuplicateIcon

--- a/src/resources/icons/Edit.tsx
+++ b/src/resources/icons/Edit.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const EditIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const EditIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.751 21.76"
@@ -27,7 +32,5 @@ const EditIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-EditIcon.defaultProps = defaultProps
 
 export default EditIcon

--- a/src/resources/icons/Exclude.tsx
+++ b/src/resources/icons/Exclude.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const ExcludeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const ExcludeIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 13.5 1.5"
@@ -20,7 +25,5 @@ const ExcludeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-ExcludeIcon.defaultProps = defaultProps
 
 export default ExcludeIcon

--- a/src/resources/icons/Globe.tsx
+++ b/src/resources/icons/Globe.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const GlobeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const GlobeIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -65,7 +69,5 @@ const GlobeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }
     </svg>
   )
 }
-
-GlobeIcon.defaultProps = defaultProps
 
 export default GlobeIcon

--- a/src/resources/icons/Help.tsx
+++ b/src/resources/icons/Help.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const HelpIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const HelpIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 26 26"
@@ -22,7 +27,5 @@ const HelpIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-HelpIcon.defaultProps = defaultProps
 
 export default HelpIcon

--- a/src/resources/icons/Html.tsx
+++ b/src/resources/icons/Html.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const HtmlIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const HtmlIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 19.316 21.495"
@@ -26,7 +31,5 @@ const HtmlIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-HtmlIcon.defaultProps = defaultProps
 
 export default HtmlIcon

--- a/src/resources/icons/Image.tsx
+++ b/src/resources/icons/Image.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const ImageIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const ImageIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.808 21.5"
@@ -24,7 +29,5 @@ const ImageIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }
     </svg>
   )
 }
-
-ImageIcon.defaultProps = defaultProps
 
 export default ImageIcon

--- a/src/resources/icons/Include.tsx
+++ b/src/resources/icons/Include.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const IncludeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const IncludeIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 13.5 13.5"
@@ -17,7 +22,5 @@ const IncludeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-IncludeIcon.defaultProps = defaultProps
 
 export default IncludeIcon

--- a/src/resources/icons/Info.tsx
+++ b/src/resources/icons/Info.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const InfoIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const InfoIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -22,7 +27,5 @@ const InfoIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-InfoIcon.defaultProps = defaultProps
 
 export default InfoIcon

--- a/src/resources/icons/InfoCurlyBorder.tsx
+++ b/src/resources/icons/InfoCurlyBorder.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const InfoCurlyBorder: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const InfoCurlyBorder: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 26.293 26.301"
@@ -27,7 +32,5 @@ const InfoCurlyBorder: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...
     </svg>
   )
 }
-
-InfoCurlyBorder.defaultProps = defaultProps
 
 export default InfoCurlyBorder

--- a/src/resources/icons/InfoFilled.tsx
+++ b/src/resources/icons/InfoFilled.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const InfoFilledIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const InfoFilledIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 20 20"
@@ -18,7 +22,5 @@ const InfoFilledIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-InfoFilledIcon.defaultProps = defaultProps
 
 export default InfoFilledIcon

--- a/src/resources/icons/Invisibility.tsx
+++ b/src/resources/icons/Invisibility.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const InvisibilityIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const InvisibilityIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 22.557 22.557"
@@ -27,7 +32,5 @@ const InvisibilityIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ..
     </svg>
   )
 }
-
-InvisibilityIcon.defaultProps = defaultProps
 
 export default InvisibilityIcon

--- a/src/resources/icons/Invoice.tsx
+++ b/src/resources/icons/Invoice.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const InvoiceIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const InvoiceIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.943 25.55"
@@ -27,7 +32,5 @@ const InvoiceIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-InvoiceIcon.defaultProps = defaultProps
 
 export default InvoiceIcon

--- a/src/resources/icons/LeftArrow.tsx
+++ b/src/resources/icons/LeftArrow.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const LeftArrowIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const LeftArrowIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 18.384 10.202"
@@ -23,7 +28,5 @@ const LeftArrowIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-LeftArrowIcon.defaultProps = defaultProps
 
 export default LeftArrowIcon

--- a/src/resources/icons/LeftChevron.tsx
+++ b/src/resources/icons/LeftChevron.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const LeftChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const LeftChevronIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -26,7 +31,5 @@ const LeftChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...
     </svg>
   )
 }
-
-LeftChevronIcon.defaultProps = defaultProps
 
 export default LeftChevronIcon

--- a/src/resources/icons/Login.tsx
+++ b/src/resources/icons/Login.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const LoginIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const LoginIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 20.54"
@@ -21,7 +26,5 @@ const LoginIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }
     </svg>
   )
 }
-
-LoginIcon.defaultProps = defaultProps
 
 export default LoginIcon

--- a/src/resources/icons/Logout.tsx
+++ b/src/resources/icons/Logout.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const LogoutIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const LogoutIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 20.54"
@@ -21,7 +26,5 @@ const LogoutIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest 
     </svg>
   )
 }
-
-LogoutIcon.defaultProps = defaultProps
 
 export default LogoutIcon

--- a/src/resources/icons/Map.tsx
+++ b/src/resources/icons/Map.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const MapIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const MapIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.21 18.931"
@@ -27,7 +32,5 @@ const MapIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) 
     </svg>
   )
 }
-
-MapIcon.defaultProps = defaultProps
 
 export default MapIcon

--- a/src/resources/icons/Mobile.tsx
+++ b/src/resources/icons/Mobile.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const MobileIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const MobileIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 30 36.8"
@@ -24,7 +29,5 @@ const MobileIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest 
     </svg>
   )
 }
-
-MobileIcon.defaultProps = defaultProps
 
 export default MobileIcon

--- a/src/resources/icons/Notification.tsx
+++ b/src/resources/icons/Notification.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const NotificationIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const NotificationIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 17.565 21.62"
@@ -26,7 +31,5 @@ const NotificationIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ..
     </svg>
   )
 }
-
-NotificationIcon.defaultProps = defaultProps
 
 export default NotificationIcon

--- a/src/resources/icons/Paused.tsx
+++ b/src/resources/icons/Paused.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const PausedIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const PausedIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg viewBox="0 0 9 9" xmlns="http://www.w3.org/2000/svg" width={size} height={size} {...rest}>
       <g data-name="paused icon">
@@ -19,7 +23,5 @@ const PausedIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest 
     </svg>
   )
 }
-
-PausedIcon.defaultProps = defaultProps
 
 export default PausedIcon

--- a/src/resources/icons/Refresh.tsx
+++ b/src/resources/icons/Refresh.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const RefreshIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const RefreshIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.779 21.5"
@@ -20,7 +25,5 @@ const RefreshIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest
     </svg>
   )
 }
-
-RefreshIcon.defaultProps = defaultProps
 
 export default RefreshIcon

--- a/src/resources/icons/RightArrow.tsx
+++ b/src/resources/icons/RightArrow.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const RightArrowIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const RightArrowIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 18.384 10.202"
@@ -23,7 +28,5 @@ const RightArrowIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...r
     </svg>
   )
 }
-
-RightArrowIcon.defaultProps = defaultProps
 
 export default RightArrowIcon

--- a/src/resources/icons/RightChevron.tsx
+++ b/src/resources/icons/RightChevron.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const RightChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const RightChevronIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -26,7 +31,5 @@ const RightChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ..
     </svg>
   )
 }
-
-RightChevronIcon.defaultProps = defaultProps
 
 export default RightChevronIcon

--- a/src/resources/icons/SendCrypto.tsx
+++ b/src/resources/icons/SendCrypto.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const SendCryptoIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const SendCryptoIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 34.533 34.533"
@@ -29,7 +34,5 @@ const SendCryptoIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...r
     </svg>
   )
 }
-
-SendCryptoIcon.defaultProps = defaultProps
 
 export default SendCryptoIcon

--- a/src/resources/icons/Staking.tsx
+++ b/src/resources/icons/Staking.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const StakingIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const StakingIcon: React.FC<AppIconProps> = ({ size = defaultProps.size, ...rest }) => {
   return (
     <svg
       viewBox="0 0 21.5 22.25"
@@ -44,7 +44,5 @@ const StakingIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-StakingIcon.defaultProps = defaultProps
 
 export default StakingIcon

--- a/src/resources/icons/Statements.tsx
+++ b/src/resources/icons/Statements.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const StatementsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const StatementsIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 24.057 25.861"
@@ -32,7 +37,5 @@ const StatementsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...r
     </svg>
   )
 }
-
-StatementsIcon.defaultProps = defaultProps
 
 export default StatementsIcon

--- a/src/resources/icons/Stop.tsx
+++ b/src/resources/icons/Stop.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const StopIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const StopIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg viewBox="0 0 9 9" xmlns="http://www.w3.org/2000/svg" width={size} height={size} {...rest}>
       <path
@@ -14,7 +18,5 @@ const StopIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-StopIcon.defaultProps = defaultProps
 
 export default StopIcon

--- a/src/resources/icons/Time.tsx
+++ b/src/resources/icons/Time.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const TimeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const TimeIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 24.057 25.861"
@@ -23,7 +28,5 @@ const TimeIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest })
     </svg>
   )
 }
-
-TimeIcon.defaultProps = defaultProps
 
 export default TimeIcon

--- a/src/resources/icons/TreeDotsMenu.tsx
+++ b/src/resources/icons/TreeDotsMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const TreeDotsMenu: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const TreeDotsMenu: React.FC<AppIconProps> = ({ size = defaultProps.size, ...rest }) => {
   return (
     <svg
       id="three-dots-menu"
@@ -42,7 +42,5 @@ const TreeDotsMenu: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...res
     </svg>
   )
 }
-
-TreeDotsMenu.defaultProps = defaultProps
 
 export default TreeDotsMenu

--- a/src/resources/icons/UnderReview.tsx
+++ b/src/resources/icons/UnderReview.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const UnderReviewIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const UnderReviewIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 14 14"
@@ -33,7 +37,5 @@ const UnderReviewIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-UnderReviewIcon.defaultProps = defaultProps
 
 export default UnderReviewIcon

--- a/src/resources/icons/UpChevron.tsx
+++ b/src/resources/icons/UpChevron.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const UpChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const UpChevronIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.5 21.5"
@@ -26,7 +31,5 @@ const UpChevronIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...re
     </svg>
   )
 }
-
-UpChevronIcon.defaultProps = defaultProps
 
 export default UpChevronIcon

--- a/src/resources/icons/Url.tsx
+++ b/src/resources/icons/Url.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const UrlIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const UrlIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 19.682 11.5"
@@ -24,7 +29,5 @@ const UrlIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) 
     </svg>
   )
 }
-
-UrlIcon.defaultProps = defaultProps
 
 export default UrlIcon

--- a/src/resources/icons/Validators.tsx
+++ b/src/resources/icons/Validators.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const ValidatorsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const ValidatorsIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 18.7 21.737"
@@ -20,7 +25,5 @@ const ValidatorsIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...r
     </svg>
   )
 }
-
-ValidatorsIcon.defaultProps = defaultProps
 
 export default ValidatorsIcon

--- a/src/resources/icons/Visibility.tsx
+++ b/src/resources/icons/Visibility.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const VisibilityIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const VisibilityIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.835 18.414"
@@ -29,7 +34,5 @@ const VisibilityIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...r
     </svg>
   )
 }
-
-VisibilityIcon.defaultProps = defaultProps
 
 export default VisibilityIcon

--- a/src/resources/icons/Withdraw.tsx
+++ b/src/resources/icons/Withdraw.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const WithdrawIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...rest }) => {
+const WithdrawIcon: React.FC<AppIconProps> = ({
+  color = defaultProps.color,
+  size = defaultProps.size,
+  strokeWidth = defaultProps.strokeWidth,
+  ...rest
+}) => {
   return (
     <svg
       viewBox="0 0 21.811 18.5"
@@ -24,7 +29,5 @@ const WithdrawIcon: React.FC<AppIconProps> = ({ color, size, strokeWidth, ...res
     </svg>
   )
 }
-
-WithdrawIcon.defaultProps = defaultProps
 
 export default WithdrawIcon

--- a/src/resources/networks/Ethereum.tsx
+++ b/src/resources/networks/Ethereum.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const EthereumIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const EthereumIcon: React.FC<AppIconProps> = ({ size = defaultProps.size, ...rest }) => {
   return (
     <svg
       viewBox="0 0 32 32"
@@ -27,7 +27,5 @@ const EthereumIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-EthereumIcon.defaultProps = defaultProps
 
 export default EthereumIcon

--- a/src/resources/networks/Polygon.tsx
+++ b/src/resources/networks/Polygon.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AppIconProps, defaultProps } from 'types/components/Icon'
 
-const PolygonIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
+const PolygonIcon: React.FC<AppIconProps> = ({ size = defaultProps.size, ...rest }) => {
   return (
     <svg
       viewBox="0 0 32 32"
@@ -20,7 +20,5 @@ const PolygonIcon: React.FC<AppIconProps> = ({ color, size, ...rest }) => {
     </svg>
   )
 }
-
-PolygonIcon.defaultProps = defaultProps
 
 export default PolygonIcon


### PR DESCRIPTION
Setting default values directly in the props instead of using defaultProps, as it is being deprecated and logs errors in the console.